### PR TITLE
Workflow should not fail code-block directive if PR contains automated content

### DIFF
--- a/content/cluster-to-cluster-sync/master/source/faq.txt
+++ b/content/cluster-to-cluster-sync/master/source/faq.txt
@@ -141,6 +141,12 @@ error:
 
    Invalid URI option, write concern must be majority
 
+Adding a new random code block directive to test code-block workflow.
+
+.. code-block:: shell
+
+   Invalid URI option, write concern must be majority
+
 ``mongosync`` accepts all other :ref:`connection string options
 <mongodb-uri>`.
 


### PR DESCRIPTION
- [x] This PR contains automated content generated from external sources