### PR TITLE
PR should trigger CI workflow run, should skip code-block check

### DIFF
--- a/content/cluster-to-cluster-sync/master/source/faq.txt
+++ b/content/cluster-to-cluster-sync/master/source/faq.txt
@@ -141,6 +141,14 @@ error:
 
    Invalid URI option, write concern must be majority
 
+Add a new code block directive. This PR will have the automated content checkbox
+checked, so it should not trigger the code-block check and should not fail in
+CI.
+
+.. code-block:: text
+
+   This is a random new code block showing some text.
+
 ``mongosync`` accepts all other :ref:`connection string options
 <mongodb-uri>`.
 


### PR DESCRIPTION
With the following checkbox checked, this PR _should_ trigger the workflow run that checks for deprecated code-block directives, but it _should not_ fail the CI. It should detect this checkbox and exit the workflow without checking for deprecated directives.

- [X] This PR contains automated content generated from external sources