### PR TITLE
PR should trigger workflow, skip code-block check

### DIFF
--- a/content/cluster-to-cluster-sync/master/source/faq.txt
+++ b/content/cluster-to-cluster-sync/master/source/faq.txt
@@ -141,6 +141,14 @@ error:
 
    Invalid URI option, write concern must be majority
 
+Add a new code block directive. This PR will have the automated content checkbox
+checked, so it should not trigger the code-block check and should not fail in
+CI.
+
+.. code-block:: text
+
+   This is a random new code block showing some text.
+
 ``mongosync`` accepts all other :ref:`connection string options
 <mongodb-uri>`.
 


### PR DESCRIPTION
When a PR contains the following checkbox, and the checkbox is checked, it should skip the step of checking for code-block or code directives, and the CI workflow should pass.

- [X] This PR contains automated content generated from external sources