### PR TITLE
PR should trigger workflow, not skip check code block step, should fail

### DIFF
--- a/content/cluster-to-cluster-sync/master/source/faq.txt
+++ b/content/cluster-to-cluster-sync/master/source/faq.txt
@@ -141,6 +141,13 @@ error:
 
    Invalid URI option, write concern must be majority
 
+Add a new code block directive. This PR will have the automated content checkbox
+UNCHECKED, so it should trigger the code-block check and should fail in CI.
+
+.. code-block:: text
+
+   This is a random new code block showing some text.
+
 ``mongosync`` accepts all other :ref:`connection string options
 <mongodb-uri>`.
 


### PR DESCRIPTION
When a PR contains the following checkbox, and the checkbox is unchecked, it should NOT skip the step of checking for code-block or code directives, and the CI workflow should fail if the PR contains a new instance of one of these deprecated directives.

- [ ] This PR contains automated content generated from external sources