### PR TITLE
PR should trigger initial fail, subsequent pass

### DIFF
--- a/content/cluster-to-cluster-sync/master/source/faq.txt
+++ b/content/cluster-to-cluster-sync/master/source/faq.txt
@@ -149,6 +149,9 @@ If I check the checkbox after making the PR with the unchecked checkbox, will
 a subsequent run of the CI pass? This should test a writer forgetting to check
 the checkbox, but then correcting it after making the PR.
 
+Subsequent run does not pass on changing checkbox state. What if I add a
+new commit to trigger a new workflow run?
+
 .. code-block:: text
 
    This is a random new code block showing some text.

--- a/content/cluster-to-cluster-sync/master/source/faq.txt
+++ b/content/cluster-to-cluster-sync/master/source/faq.txt
@@ -141,6 +141,18 @@ error:
 
    Invalid URI option, write concern must be majority
 
+Add a new code block directive. This PR will have the automated content checkbox
+UNCHECKED initially, so it should trigger the code-block check and should fail
+in CI.
+
+If I check the checkbox after making the PR with the unchecked checkbox, will
+a subsequent run of the CI pass? This should test a writer forgetting to check
+the checkbox, but then correcting it after making the PR.
+
+.. code-block:: text
+
+   This is a random new code block showing some text.
+
 ``mongosync`` accepts all other :ref:`connection string options
 <mongodb-uri>`.
 


### PR DESCRIPTION
When a PR contains the following checkbox, and the checkbox is unchecked, it should NOT skip the step of checking for code-block or code directives, and the CI workflow should fail if the PR contains a new instance of one of these deprecated directives.

However, 🤞 - if the writer then subsequently changes the checkbox value and triggers a new CI run, the CI should pass.

- [x] This PR contains automated content generated from external sources